### PR TITLE
Added check for kubectl executable and kubectl client

### DIFF
--- a/kubectl-exec
+++ b/kubectl-exec
@@ -3,21 +3,28 @@
 #Check kubectl client exists
 if ! command -v kubectl &> /dev/null
 then
-    echo "Kubectl client could not be found. Please install Kubectl client before running kubectl-exec.\n REF: https://kubernetes.io/docs/tasks/tools/"
+    printf "Kubectl client could not be found. Please install Kubectl client before running kubectl-exec.\nRefer to: https://kubernetes.io/docs/tasks/tools/\n\n"
     exit 1
 fi
+
+
 
 #Check client major/minor versions
 kubectl_major_version=$(kubectl version --client -o yaml | grep -i "major" | awk '{ print $2 }' | sed 's/"//g')
 kubectl_minor_version=$(kubectl version --client -o yaml | grep -i "minor" | awk '{ print $2 }' | sed 's/"//g')
 
-if [[ $kubectl_major_version -gt 1 || $kubectl_major_version -eq 1 && $kubectl_minor_version -ge 20 ]]
+if [[ $kubectl_major_version -gt 1 ]] || [[ $kubectl_major_version -eq 1 && $kubectl_minor_version -ge 18 ]]
 then
         use_generator=false
-else
+        echo "Kuberetes client version is $kubectl_major_version.$kubectl_minor_version. Generator will not be used since it is deprecated."
+elif [[ $kubectl_major_version -eq 1 && $kubectl_minor_version -lt 18 ]]
+then
         use_generator=true
+        echo "Kuberetes client version is $kubectl_major_version.$kubectl_minor_version. Generator will be used."
+else
+        echo "Invalid kubectl version, exiting."
+        exit 1
 fi
-echo $use_generator
 
 #Usage message
 usage()
@@ -91,7 +98,7 @@ EOT
 )"
 
 echo "creating pod \"$POD\" on node \"$NODE\""
-if [ $use_generator -eq true]
+if [ $use_generator = true ]
 then
         kubectl run --rm --image $IMAGE --overrides="$OVERRIDES" --generator=run-pod/v1 -ti "$POD"
 else

--- a/kubectl-exec
+++ b/kubectl-exec
@@ -7,8 +7,6 @@ then
     exit 1
 fi
 
-
-
 #Check client major/minor versions
 kubectl_major_version=$(kubectl version --client -o yaml | grep -i "major" | awk '{ print $2 }' | sed 's/"//g')
 kubectl_minor_version=$(kubectl version --client -o yaml | grep -i "minor" | awk '{ print $2 }' | sed 's/"//g')
@@ -106,7 +104,6 @@ else
 fi
 }
 
-
 #windows function to ssh to windows nodes
 WINDOWSNODES () {
 
@@ -147,7 +144,7 @@ EOT
 
 echo "creating pod \"$POD\" for windows ssh"
 
-if [ $use_generator -eq true]
+if [ $use_generator = true]
 then
         kubectl run --rm --image $IMAGE --overrides="$OVERRIDES" --generator=run-pod/v1 -ti "$POD"
 else

--- a/kubectl-exec
+++ b/kubectl-exec
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+#Check kubectl client exists
+if ! command -v kubectl &> /dev/null
+then
+    echo "Kubectl client could not be found. Please install Kubectl client before running kubectl-exec.\n REF: https://kubernetes.io/docs/tasks/tools/"
+    exit 1
+fi
+
+#Check client major/minor versions
+kubectl_major_version=$(kubectl version --client -o yaml | grep -i "major" | awk '{ print $2 }' | sed 's/"//g')
+kubectl_minor_version=$(kubectl version --client -o yaml | grep -i "minor" | awk '{ print $2 }' | sed 's/"//g')
+
+if [[ $kubectl_major_version -gt 1 || $kubectl_major_version -eq 1 && $kubectl_minor_version -ge 20 ]]
+then
+        use_generator=false
+else
+        use_generator=true
+fi
+echo $use_generator
+
 #Usage message
 usage()
 {
@@ -72,7 +91,12 @@ EOT
 )"
 
 echo "creating pod \"$POD\" on node \"$NODE\""
-kubectl run --rm --image $IMAGE --overrides="$OVERRIDES" --generator=run-pod/v1 -ti "$POD"
+if [ $use_generator -eq true]
+then
+        kubectl run --rm --image $IMAGE --overrides="$OVERRIDES" --generator=run-pod/v1 -ti "$POD"
+else
+        kubectl run --rm --image $IMAGE --overrides="$OVERRIDES" -ti "$POD"
+fi
 }
 
 
@@ -115,7 +139,14 @@ EOT
 )"
 
 echo "creating pod \"$POD\" for windows ssh"
-kubectl run --rm --image $IMAGE --overrides="$OVERRIDES" --generator=run-pod/v1 -ti "$POD"
+
+if [ $use_generator -eq true]
+then
+        kubectl run --rm --image $IMAGE --overrides="$OVERRIDES" --generator=run-pod/v1 -ti "$POD"
+else
+        kubectl run --rm --image $IMAGE --overrides="$OVERRIDES" -ti "$POD"
+fi
+
 }
 
 #Evaluate if windows node.


### PR DESCRIPTION
Kubectl client version 1.21 (currently used in Cloud Shell) causes the kubectl-exec application to fail since --generator flag is completely deprecated.
I added a check for the client itself, and also if statements to cater for the version differences.
Essentially, any version of kubectl client higher than 1.17 will no longer use the generator flag for both Windows and Linux nodes.