### PR TITLE
Add support to attach process.

### DIFF
--- a/kubectl-exec
+++ b/kubectl-exec
@@ -63,7 +63,10 @@ LINUXNODES () {
     "containers": [
       {
         "securityContext": {
-          "privileged": true
+          "privileged": true,
+          "capabilities": {
+               "add": [ "SYS_PTRACE" ]
+          }
         },
         "image": "$IMAGE",
         "name": "nsenter",
@@ -110,7 +113,10 @@ read -p "Enter the windows node ssh user: " WINDOWSSSHUSER
     "containers": [
       {
         "securityContext": {
-          "privileged": true
+          "privileged": true,
+          "capabilities": {
+               "add": [ "SYS_PTRACE" ]
+          }
         },
         "image": "$IMAGE",
         "name": "nsenter",
@@ -155,7 +161,10 @@ LINUXHOSTMOUNT () {
     "containers": [
       {
         "securityContext": {
-          "privileged": true
+          "privileged": true,
+          "capabilities": {
+               "add": [ "SYS_PTRACE" ]
+          }
         },
         "image": "$IMAGE",
         "volumeMounts": [


### PR DESCRIPTION
Beside setting privileged container, we need to explicitly
add SYS_PTRACE capability so that GDB/dlv tool can attach
running process in the k8s nodes.

See [Github issue.](https://github.com/MicrosoftDocs/azure-docs/issues/79825)