### PR TITLE
Fix unbound variable

### DIFF
--- a/kubectl-exec
+++ b/kubectl-exec
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 #Check kubectl client exists
 if ! command -v kubectl &> /dev/null
@@ -54,7 +55,7 @@ usage()
 LINUXNODES () {
 
     IMAGE="alpine"
-    POD="$NODE-exec-$(echo $RANDOM)"
+    POD="${NODE}-exec-${RANDOM}"
 
     # Check the node existence
     kubectl get node "$NODE" >/dev/null || exit 1
@@ -99,15 +100,15 @@ fi
 WINDOWSNODES () {
 
 echo "SSH into windows VM"
-read -p "Enter your windows node ssh user: " WINDOWSSSHUSER
-read -s -p "Enter your windows ssh password: " WINDOWSSSHPASSWORD
+read -r -p "Enter your windows node ssh user: " WINDOWSSSHUSER
+read -r -s -p "Enter your windows ssh password: " WINDOWSSSHPASSWORD
 
     IMAGE="mohatb/alpine:latest"
     POD="$NODE-exec-$(env LC_CTYPE=C tr -dc a-z0-9 < /dev/urandom | head -c 6)"
 
     # Check the node existence and IP
     kubectl get nodes "$NODE" -o wide >/dev/null || exit 1
-    WINNODEIP=$(kubectl get node $NODE --output=jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+    WINNODEIP=$(kubectl get node "$NODE" --output=jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
 
     #nsenter JSON overrrides
     OVERRIDES="$(cat <<EOT
@@ -218,10 +219,10 @@ WINDOWSHOSTMOUNT () {
 
     # Check the node existence
     kubectl get node "$NODE" >/dev/null || exit 1
-    read -p "Enter the windows ssh username: " WINDOWSSSHUSERNAME
-    read -s -p "Enter the windows ssh password: " WINDOWSSSHPASSWORD
+    read -r -p "Enter the windows ssh username: " WINDOWSSSHUSERNAME
+    read -r -s -p "Enter the windows ssh password: " WINDOWSSSHPASSWORD
     echo ""
-    WINDOWSIPADDRESS=$(kubectl get node $NODE --output=jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+    WINDOWSIPADDRESS=$(kubectl get node "$NODE" --output=jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
     
     OVERRIDES="$(cat <<EOT
 {
@@ -352,9 +353,9 @@ EXECFILEMANAGERWINDOWS() {
 
     # Check the node existence
     kubectl get node "$NODE" >/dev/null || exit 1
-    read -p "Enter the windows ssh username: " WINDOWSSSHUSERNAME
-    read -s -p "Enter the windows ssh password: " WINDOWSSSHPASSWORD
-    WINDOWSIPADDRESS=$(kubectl get node $NODE --output=jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+    read -r -p "Enter the windows ssh username: " WINDOWSSSHUSERNAME
+    read -r -s -p "Enter the windows ssh password: " WINDOWSSSHPASSWORD
+    WINDOWSIPADDRESS=$(kubectl get node "$NODE" --output=jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
 
     OVERRIDES="$(cat <<EOT
 {
@@ -416,19 +417,17 @@ fi
 #Colors for echo command
 RED='\033[0;31m'
 BLUE='\033[0;34m'
-Green='\033[0;32m'
 NC='\033[0m'
 
 
 #check if user is looking for documentation with -h
-if [ "$1" = "-h" ]
+if [ "${1-}" = "-h" ]
 then
         usage
-        exit 1
 fi
 
 #Check user input for shell access
-if [ -z "$1" ]; then
+if [ -z "${1-}" ]; then
         
         mapfile -t nodenumber < <( kubectl get nodes --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' )
 
@@ -436,18 +435,18 @@ if [ -z "$1" ]; then
           printf "$i ${nodenumber[i]} \n"
         done
         
-        read -p "Enter the node number: " NODE_INDEX
+        read -r -p "Enter the node number: " NODE_INDEX
         NODE=${nodenumber[NODE_INDEX]}
 
     else
-        NODE=$1
+        NODE=${1-}
     fi
 
 #Statement to check if user is looking to mount root file system in linux nodes to the pod.
-if [ "$1" = "-mount" ] && [ -n "$2" ]; then
+if [ "${1-}" = "-mount" ] && [ -n "${2-}" ]; then
 #Check if the user provided node number
        NODE="$2"
-       NODEOS=$(kubectl get node $NODE -o jsonpath="{.metadata.labels.\kubernetes\.io/os}")
+       NODEOS=$(kubectl get node "$NODE" -o jsonpath="{.metadata.labels.\kubernetes\.io/os}")
           if [[ $NODEOS = "windows" ]]
           then
               WINDOWSHOSTMOUNT
@@ -456,8 +455,7 @@ if [ "$1" = "-mount" ] && [ -n "$2" ]; then
               LINUXHOSTMOUNT
               exit 1
           fi
-        exit 1
-  elif [ "$1" = "-mount" ] && [ -z "$2" ]; then
+  elif [ "${1-}" = "-mount" ] && [ -z "${2-}" ]; then
 #If the user did not provide a node number, use interactive to get it.
 		mapfile -t nodenumber < <( kubectl get nodes --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' )
 
@@ -465,9 +463,9 @@ if [ "$1" = "-mount" ] && [ -n "$2" ]; then
           printf "$i ${nodenumber[i]} \n"
         done
         
-        read -p "Enter the node number: " NODE_INDEX
+        read -r -p "Enter the node number: " NODE_INDEX
         NODE=${nodenumber[NODE_INDEX]}
-        NODEOS=$(kubectl get node $NODE -o jsonpath="{.metadata.labels.\kubernetes\.io/os}")
+        NODEOS=$(kubectl get node "$NODE" -o jsonpath="{.metadata.labels.\kubernetes\.io/os}")
         if [[ $NODEOS = "windows" ]]
           then
               WINDOWSHOSTMOUNT
@@ -476,14 +474,13 @@ if [ "$1" = "-mount" ] && [ -n "$2" ]; then
               LINUXHOSTMOUNT
               exit 1
         fi
-        exit 1
 fi
 
 #Statement to check if user is looking to mount root file system in linux nodes to the pod.
-if [ "$1" = "-filemanager" ] && [ -n "$2" ]; then
+if [ "${1-}" = "-filemanager" ] && [ -n "${2-}" ]; then
 #Check if the user provided node number
        NODE="$2"
-       NODEOS=$(kubectl get node $NODE -o jsonpath="{.metadata.labels.\kubernetes\.io/os}")
+       NODEOS=$(kubectl get node "$NODE" -o jsonpath="{.metadata.labels.\kubernetes\.io/os}")
           if [[ $NODEOS = "windows" ]]
           then
               EXECFILEMANAGERWINDOWS
@@ -492,17 +489,16 @@ if [ "$1" = "-filemanager" ] && [ -n "$2" ]; then
               EXECFILEMANAGERLINUX
               exit 1
           fi
-        exit 1
 #If the user did not provide a node number, use interactive to get it.
-  elif [ "$1" = "-filemanager" ] && [ -z "$2" ]; then
+  elif [ "${1-}" = "-filemanager" ] && [ -z "${2-}" ]; then
 		mapfile -t nodenum < <( kubectl get nodes --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' )
         for i in "${!nodenum[@]}"; do
           printf "$i ${nodenum[i]} \n"
         done
         
-        read -p "Enter the node number: " NODE_INDEX
+        read -r -p "Enter the node number: " NODE_INDEX
         NODE=${nodenum[NODE_INDEX]}
-        NODEOS=$(kubectl get node $NODE -o jsonpath="{.metadata.labels.\kubernetes\.io/os}")
+        NODEOS=$(kubectl get node "$NODE" -o jsonpath="{.metadata.labels.\kubernetes\.io/os}")
         if [[ $NODEOS = "windows" ]]
           then
               EXECFILEMANAGERWINDOWS
@@ -511,11 +507,10 @@ if [ "$1" = "-filemanager" ] && [ -n "$2" ]; then
               EXECFILEMANAGERLINUX
               exit 1
         fi
-        exit 1
 fi
 
 #Evaluate if windows node.
-NODEOS=$(kubectl get node $NODE -o jsonpath="{.metadata.labels.\kubernetes\.io/os}")
+NODEOS=$(kubectl get node "$NODE" -o jsonpath="{.metadata.labels.\kubernetes\.io/os}")
 
 if [[ $NODEOS = "windows" ]]
 then


### PR DESCRIPTION
## Summary
- avoid unbound positional parameters when running with `set -u`

## Testing
- `bash -n kubectl-exec`
- `shellcheck -x kubectl-exec`

------
https://chatgpt.com/codex/tasks/task_e_688749f9a79c832aa1cb745a2a3376e0